### PR TITLE
Alteração de domínio para a API de Planos e Assinaturas removendo beta

### DIFF
--- a/subscription.yaml
+++ b/subscription.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   title: Planos e Assinaturas
 basePath: /v1
-host: api-beta.zoop.ws
+host: api.zoop.ws
 securityDefinitions:
   basicAuth:
     type: basic


### PR DESCRIPTION
Voltando para a URL anterior. Houve um engano e a API já está em produção